### PR TITLE
Overzealous 2to3

### DIFF
--- a/darts/lib/utils/lru.py
+++ b/darts/lib/utils/lru.py
@@ -668,7 +668,7 @@ class SynchronizedLRUDict(object):
         """
 
         with self.__lock:
-            return iter(tuple(self.__dict.values()))
+            return iter(tuple(self.__dict.itervalues()))
 
     def iteritems(self):
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = "darts.util.lru",
+    name = "darts_util_lru",
     version = "0.5",
     description='Simple dictionary with LRU behaviour',
     zip_safe=True,


### PR DESCRIPTION
The __dict object here still implements the itervalues API (since __dict is a DartLRU). So this call cannot be updated to '.values()'